### PR TITLE
Several Keyboard/Gamepad input improvements

### DIFF
--- a/app/src/main/java/ru/henridellal/emerald/AppData.java
+++ b/app/src/main/java/ru/henridellal/emerald/AppData.java
@@ -1,6 +1,9 @@
 package ru.henridellal.emerald;
 
+import android.content.ComponentName;
 import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
 import android.database.Cursor;
 
 import java.io.BufferedReader;
@@ -15,7 +18,7 @@ public class AppData extends BaseData {
 	public static final String NAME = "N";
 	
 	private ArrayList<String> categories;
-	
+
 	@Override
 	public boolean equals(Object a) {
 		if (! (a instanceof AppData))
@@ -25,15 +28,7 @@ public class AppData extends BaseData {
 		}
 		return component.equals( ((AppData)a).component );
 	}
-	
-	@Override
-	public int hashCode() {
-		if (component == null)
-			return "NULL null NULL".hashCode();
-		else
-			return (component).hashCode();
-	}
-	
+
 	public AppData() {
 		super();
 		categories = new ArrayList<String>();
@@ -82,6 +77,18 @@ public class AppData extends BaseData {
 		.append(NAME)
 		.append(this.name)
 		.append("\n").toString());
+	}
+
+	public Intent getLaunchIntent(Context context) {
+		//Log.v(APP_TAG, "User launched an app");
+		if (!DatabaseHelper.hasItem(context, this, CategoryManager.HIDDEN))
+			DatabaseHelper.addToHistory(context, this);
+		Intent i = new Intent(Intent.ACTION_MAIN);
+		i.addCategory(Intent.CATEGORY_LAUNCHER);
+		i.setComponent(ComponentName.unflattenFromString(getComponent()));
+		i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+
+		return i;
 	}
 
 }

--- a/app/src/main/java/ru/henridellal/emerald/Apps.java
+++ b/app/src/main/java/ru/henridellal/emerald/Apps.java
@@ -745,6 +745,10 @@ public class Apps extends Activity
 				startActivity(new Intent(this, Options.class));
 			} else if (keyCode == KeyEvent.KEYCODE_H && !lock) {
 				toggleHiddenCategory();
+			} else if (keyCode == KeyEvent.KEYCODE_R && !lock) {
+				if (null != mGetAppsThread)
+					mGetAppsThread.quit();
+				loadAppsFromSystem(true);
 			} else {
 				return super.onKeyDown(keyCode, event);
 			}

--- a/app/src/main/java/ru/henridellal/emerald/BaseData.java
+++ b/app/src/main/java/ru/henridellal/emerald/BaseData.java
@@ -1,11 +1,14 @@
 package ru.henridellal.emerald;
 
+import android.content.Context;
+import android.content.Intent;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.Comparator;
 
-public class BaseData implements Comparable<BaseData> {
+public abstract class BaseData implements Comparable<BaseData> {
 	//component is a package name
 	protected String component;
 	
@@ -59,6 +62,8 @@ public class BaseData implements Comparable<BaseData> {
 	public int compareTo(BaseData arg0) {
 		return arg0.name.compareToIgnoreCase(this.name);
 	}
+
+	abstract public Intent getLaunchIntent(Context context);
 	
 	@Override
 	public int hashCode() {

--- a/app/src/main/java/ru/henridellal/emerald/OnAppClickListener.java
+++ b/app/src/main/java/ru/henridellal/emerald/OnAppClickListener.java
@@ -11,10 +11,8 @@ public class OnAppClickListener implements View.OnClickListener {
 	
 	@Override
 	public void onClick(View arg0) {
-		if (arg0.getTag() instanceof AppData) {
-			appsRef.get().launch((AppData)arg0.getTag());
-		} else if (arg0.getTag() instanceof ShortcutData) {
-			appsRef.get().launch((ShortcutData)arg0.getTag());
+		if (arg0.getTag() instanceof BaseData) {
+			appsRef.get().launch((BaseData)arg0.getTag());
 		}
 	}
 }

--- a/app/src/main/java/ru/henridellal/emerald/ShortcutData.java
+++ b/app/src/main/java/ru/henridellal/emerald/ShortcutData.java
@@ -1,6 +1,9 @@
 package ru.henridellal.emerald;
 
+import android.content.Context;
+import android.content.Intent;
 import android.database.Cursor;
+import android.widget.Toast;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -68,6 +71,19 @@ public class ShortcutData extends BaseData {
 		.append(this.uri)
 		.append("\n").toString());
 	}
+
+	@Override
+	public Intent getLaunchIntent(Context context) {
+		if (!DatabaseHelper.hasItem(context, this, CategoryManager.HIDDEN))
+			DatabaseHelper.addToHistory(context, this);
+		try {
+			return Intent.parseUri(getUri(), 0);
+		} catch (Exception e) {
+			Toast.makeText(context, e.toString(), Toast.LENGTH_LONG).show();
+			return null;
+		}
+	}
+
 	@Override
 	public int hashCode() {
 		return getUri().hashCode();

--- a/app/src/main/res/drawable/button_background.xml
+++ b/app/src/main/res/drawable/button_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item android:state_focused = "true" android:drawable="@android:color/transparent"/>
+    <item android:state_focused = "true" android:drawable="@color/focused"/>
     <item android:state_pressed = "true" android:drawable="@color/selector"/>
     <item android:drawable="@android:color/transparent"/>
 </selector>

--- a/app/src/main/res/drawable/menu_bg.xml
+++ b/app/src/main/res/drawable/menu_bg.xml
@@ -2,5 +2,5 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 	<item android:state_pressed="false" android:state_focused="false" android:drawable="@drawable/menu"/>
 	<item android:state_pressed="true" android:drawable="@drawable/menu_pressed" />
-	<item android:state_focused="true" android:drawable="@drawable/menu" />
+	<item android:state_focused="true" android:drawable="@drawable/menu_dark" />
 </selector>

--- a/app/src/main/res/drawable/menu_bg.xml
+++ b/app/src/main/res/drawable/menu_bg.xml
@@ -2,5 +2,4 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 	<item android:state_pressed="false" android:state_focused="false" android:drawable="@drawable/menu"/>
 	<item android:state_pressed="true" android:drawable="@drawable/menu_pressed" />
-	<item android:state_focused="true" android:drawable="@drawable/menu_dark" />
 </selector>

--- a/app/src/main/res/drawable/menu_dark_bg.xml
+++ b/app/src/main/res/drawable/menu_dark_bg.xml
@@ -2,5 +2,4 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 	<item android:state_pressed="false" android:state_focused="false" android:drawable="@drawable/menu_dark"/>
 	<item android:state_pressed="true" android:drawable="@drawable/menu_dark_pressed" />
-	<item android:state_focused="true" android:drawable="@drawable/menu" />
 </selector>

--- a/app/src/main/res/drawable/menu_dark_bg.xml
+++ b/app/src/main/res/drawable/menu_dark_bg.xml
@@ -2,5 +2,5 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 	<item android:state_pressed="false" android:state_focused="false" android:drawable="@drawable/menu_dark"/>
 	<item android:state_pressed="true" android:drawable="@drawable/menu_dark_pressed" />
-	<item android:state_focused="true" android:drawable="@drawable/menu_dark" />
+	<item android:state_focused="true" android:drawable="@drawable/menu" />
 </selector>

--- a/app/src/main/res/drawable/search_bg.xml
+++ b/app/src/main/res/drawable/search_bg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item android:state_focused = "true" android:drawable="@drawable/search"/>
+    <item android:state_focused = "true" android:drawable="@drawable/search_dark"/>
     <item android:state_pressed = "true" android:drawable="@drawable/search_pressed"/>
     <item android:drawable="@drawable/search"/>
 </selector>

--- a/app/src/main/res/drawable/search_bg.xml
+++ b/app/src/main/res/drawable/search_bg.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item android:state_focused = "true" android:drawable="@drawable/search_dark"/>
     <item android:state_pressed = "true" android:drawable="@drawable/search_pressed"/>
     <item android:drawable="@drawable/search"/>
 </selector>

--- a/app/src/main/res/drawable/search_dark_bg.xml
+++ b/app/src/main/res/drawable/search_dark_bg.xml
@@ -2,5 +2,4 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android" >
     <item android:state_focused = "true" android:drawable="@drawable/search"/>
     <item android:state_pressed = "true" android:drawable="@drawable/search_dark_pressed"/>
-    <item android:drawable="@drawable/search_dark"/>
 </selector>

--- a/app/src/main/res/drawable/search_dark_bg.xml
+++ b/app/src/main/res/drawable/search_dark_bg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item android:state_focused = "true" android:drawable="@drawable/search_dark"/>
+    <item android:state_focused = "true" android:drawable="@drawable/search"/>
     <item android:state_pressed = "true" android:drawable="@drawable/search_dark_pressed"/>
     <item android:drawable="@drawable/search_dark"/>
 </selector>

--- a/app/src/main/res/layout/apps_grid.xml
+++ b/app/src/main/res/layout/apps_grid.xml
@@ -3,6 +3,8 @@
 	android:id="@+id/appsGrid"
 	android:layout_width="fill_parent"
 	android:layout_height="wrap_content"
+	android:descendantFocusability="blocksDescendants"
+	android:listSelector="@drawable/button_background"
 	android:numColumns="auto_fit"
 	android:columnWidth="@dimen/column_width"
 	android:verticalSpacing="@dimen/vertical_spacing"

--- a/app/src/main/res/layout/dock_bar.xml
+++ b/app/src/main/res/layout/dock_bar.xml
@@ -3,7 +3,8 @@
 	android:id="@+id/dock_bar"
 	android:layout_width="fill_parent"
 	android:layout_height="@dimen/dock_height"
-	android:background="#2000">
+	android:background="#2000"
+	android:focusableInTouchMode="false">
 	<ImageView
 		android:id="@+id/button1"
 		android:layout_width="0dp"
@@ -12,7 +13,8 @@
 		android:layout_weight="1"
 		android:visibility="invisible"
 		android:layout_alignParentLeft="true"
-		android:layout_alignParentTop="true" />
+		android:layout_alignParentTop="true"
+		android:background="@drawable/button_background" />
 	<ImageView
 		android:id="@+id/button2"
 		android:layout_width="0dp"
@@ -20,7 +22,8 @@
 		android:layout_gravity="center_vertical"
 		android:layout_weight="1"
 		android:visibility="gone"
-		android:layout_toRightOf="@id/button1" />
+		android:layout_toRightOf="@id/button1"
+		android:background="@drawable/button_background" />
 	<ImageView
 		android:id="@+id/button3"
 		android:layout_width="0dp"
@@ -28,7 +31,8 @@
 		android:layout_gravity="center_vertical"
 		android:layout_weight="1"
 		android:visibility="gone"
-		android:layout_toRightOf="@id/button2" />
+		android:layout_toRightOf="@id/button2"
+		android:background="@drawable/button_background" />
 	<ImageView
 		android:id="@+id/button4"
 		android:layout_width="0dp"
@@ -36,7 +40,8 @@
 		android:layout_gravity="center_vertical"
 		android:layout_weight="1"
 		android:visibility="gone"
-		android:layout_toRightOf="@id/button3" />
+		android:layout_toRightOf="@id/button3"
+		android:background="@drawable/button_background" />
 	<ImageView
 		android:id="@+id/button5"
 		android:layout_width="0dp"
@@ -44,5 +49,6 @@
 		android:layout_gravity="center_vertical"
 		android:layout_weight="1"
 		android:visibility="gone"
-		android:layout_toRightOf="@id/button4" />
+		android:layout_toRightOf="@id/button4"
+		android:background="@drawable/button_background" />
 </LinearLayout>

--- a/app/src/main/res/layout/iconbutton.xml
+++ b/app/src/main/res/layout/iconbutton.xml
@@ -6,6 +6,7 @@
     android:gravity="center"
     android:clickable="true"
     android:background="@drawable/button_background"
+    android:paddingTop="4dp"
     >
 <ImageView 
 android:id="@+id/icon"
@@ -19,7 +20,6 @@ android:layout_width="fill_parent"
 android:layout_height="wrap_content"
 android:gravity="top|center_horizontal"
 android:textSize="@dimen/text_size"
-android:paddingBottom="4dp"
 android:shadowColor="?attr/launcherTextShadowColor"
 android:shadowRadius="2"
 android:shadowDx="1"

--- a/app/src/main/res/layout/main_bar.xml
+++ b/app/src/main/res/layout/main_bar.xml
@@ -12,14 +12,16 @@
 		android:id="@+id/tabs"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content" >
-		<Button 
+		<ImageButton
 			android:id="@+id/menuButton"
+			android:contentDescription="@string/launcher_menu"
 			android:layout_width="32dp"
 			android:layout_height="32dp"
 			android:layout_centerVertical="true"
 			android:onClick="onMyClick"
-			android:background="?attr/drawableMenu"
-			android:layout_alignParentLeft="true" />
+			android:layout_alignParentLeft="true"
+			android:src="?attr/drawableMenu"
+			android:background="@drawable/button_background" />
 		<Button
 			android:id="@+id/category_button"
 			android:layout_width="0dp"
@@ -32,14 +34,16 @@
 			android:layout_marginLeft="5dp"
 			android:layout_marginRight="5dp"
 			android:layout_centerVertical="true" />
-		<Button 
+		<ImageButton
 			android:id="@+id/searchButton"
+			android:contentDescription="@android:string/search_go"
 			android:layout_width="32dp"
 			android:layout_height="32dp"
 			android:layout_centerVertical="true"
 			android:onClick="onMyClick"
 			android:layout_alignParentRight="true"
-			android:background="?attr/drawableSearch" />
+			android:src="?attr/drawableSearch"
+			android:background="@drawable/button_background" />
 	</RelativeLayout>
 	<RelativeLayout 
 		android:id="@+id/searchBar"
@@ -63,7 +67,7 @@
 			android:textSize="18sp"
 			android:textColor="?attr/launcherTextColor"
 			android:layout_alignParentLeft="true"
-			android:layout_toStartOf="@id/searchBar"
+			android:layout_alignParentStart="true"
 			android:layout_toLeftOf="@id/webSearchButton" />
 	</RelativeLayout>
 	<Button 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 <color name="lightTextShadow">#333</color>    
-<color name="darkTextShadow">#bbb</color>    
-<color name="selector">#4000</color>    
-<color name="dropdownTextColor">#fff</color>    
+<color name="darkTextShadow">#bbb</color>
+<color name="focused">#8888</color>
+<color name="selector">#4000</color>
+<color name="dropdownTextColor">#fff</color>
 <color name="dropdownBackground">#000</color>    
 </resources>


### PR DESCRIPTION
This is a set of changes to make the launcher usable in
Android boxes connected to TVs and so, where it's not possible
to use the touchscreen, or where a gamepad is more comfortable
than an actual keyboard.

The Keyboard navigation not always worked correctly before, the
gridview was sometimes using its selector and other times it wasn't
(depending on where the cursor came from when switching focus to the grid)
the "ENTER" key wasn't behaving properly when the gridview selector
was on, etc. These hurdles are fixed with this commit.
( Fixes #56 )

I added some color for the selector when focused so the selected item
is actually visible, as well was the menu/search buttons.

I also added some additional bindings for keyboard and gamepad:

* Alt+O: open options activity (only if not password locked)
* Alt+H: toggle showing the hidden apps (only if not password locked)
* Alt+R: run full scan to refresh list  of apps (only if not password locked)
* Escape: same behavior as back button
* Gamepad Y: context menu of the app selected
* Gamepad A: same behavior as keyboard enter
* Gamepad B: same behavior as back button
* Gamepad Select: open the options menu (asks password if locked)
* Gamepad left bumper/left thumb button: switch to previous category
* Gamepad Right bumper/right thumb button: switch to next category

Also, there's a "search as you type" now, so the search will
automatically open when typing on the physical keyboard.

Also pressing up or down from the search bar will focus the grid so it's
easier to select one of the found items to launch it.